### PR TITLE
fix(h5): resolve startup issues for H5A test containers - add python3…

### DIFF
--- a/machineH5A/Dockerfile
+++ b/machineH5A/Dockerfile
@@ -5,6 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     wget \
     curl \
+    python3 \
     perl \
     libnet-ssleay-perl \
     libio-socket-ssl-perl \


### PR DESCRIPTION
… dependency for H5A stub runtime