### PR TITLE
fix(H8C): fix startup crash, add port 9999, install vulnerable Laravel/Ignition

### DIFF
--- a/machineH8C/Dockerfile
+++ b/machineH8C/Dockerfile
@@ -2,36 +2,62 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Install all required PHP packages and tools in one go
 RUN apt-get update && apt-get install -y \
-    php \
-    php-cli \
-    php-xml \
-    php-mbstring \
-    php-curl \
-    php-zip \
+    php8.1 \
+    php8.1-cli \
+    php8.1-common \
+    php8.1-curl \
+    php8.1-mbstring \
+    php8.1-xml \
+    php8.1-zip \
+    php8.1-mysql \
+    php8.1-sqlite3 \
+    php8.1-bcmath \
+    php8.1-tokenizer \
+    php8.1-dom \
     composer \
     curl \
     wget \
     unzip \
+    python3 \
     && rm -rf /var/lib/apt/lists/*
 
-# King file
+# Create king file for SLA bot
 RUN mkdir -p /root && echo "unclaimed" > /root/king.txt && chmod 666 /root/king.txt && chmod 777 /root
 
 # Create laravel user
 RUN useradd -m -s /bin/bash laraveluser && echo 'laraveluser:laravel123' | chpasswd
 
-# PrivEsc: SUID bash available (bash -p gives root)
+# SUID bash for privilege escalation
 RUN cp /bin/bash /bin/bash_suid && chmod u+s /bin/bash_suid
 
-# Deploy Laravel 8.4.2 (vulnerable to CVE-2021-3129 debug mode RCE)
-RUN mkdir -p /opt/laravel
-COPY app/ /opt/laravel/
-RUN chown -R laraveluser:laraveluser /opt/laravel/
+COPY php.ini /etc/php/8.1/cli/conf.d/99-custom.ini
 
+# Create Laravel project (vulnerable version)
+WORKDIR /opt
+RUN composer create-project laravel/laravel=8.4.2 laravel --prefer-dist --no-interaction
+WORKDIR /opt/laravel
+
+# Install vulnerable Ignition (CVE-2021-3129)
+RUN composer require facade/ignition=2.5.1 --no-interaction
+
+# Configure .env for debug mode
+RUN cp .env.example .env && \
+    sed -i 's/APP_DEBUG=false/APP_DEBUG=true/' .env && \
+    sed -i 's/APP_ENV=local/APP_ENV=local/' .env
+
+# Generate application key
+RUN php artisan key:generate
+
+# Set permissions for storage and cache
+RUN chown -R laraveluser:laraveluser /opt/laravel/storage /opt/laravel/bootstrap/cache && \
+    chmod -R 775 /opt/laravel/storage /opt/laravel/bootstrap/cache
+
+# Copy start script
 COPY start.sh /start.sh
 RUN chmod +x /start.sh
 
-EXPOSE 8000
+EXPOSE 8000 9999
 
 CMD ["/start.sh"]

--- a/machineH8C/php.ini
+++ b/machineH8C/php.ini
@@ -1,0 +1,2 @@
+phar.readonly = Off
+allow_url_include = On

--- a/machineH8C/start.sh
+++ b/machineH8C/start.sh
@@ -1,2 +1,12 @@
 #!/bin/bash
-su -s /bin/bash laraveluser -c "python3 /opt/laravel/laravel-stub.py"
+
+# Start SLA HTTP server on port 9999
+python3 -m http.server 9999 --directory /root &
+
+sleep 2
+
+# Run Laravel development server as laraveluser
+su -s /bin/bash laraveluser -c "cd /opt/laravel && php artisan serve --host=0.0.0.0 --port=8000"
+
+# Keep alive
+tail -f /dev/null


### PR DESCRIPTION
## Summary
This PR fixes critical issues in `machineH8C`:
- Container no longer exits on startup (exit code 127). Added `python3` and fixed `start.sh`.
- Exposed port `9999` with an HTTP server serving `/root/king.txt` (SLA bot requirement).
- Installed real Laravel 8.4.2 + Ignition 2.5.1 (vulnerable to CVE-2021-3129).
- Added custom `php.ini` with `phar.readonly = Off` to enable the exploit.

## What was tested
- Container starts and stays running.
- Port 9999 returns `unclaimed` initially.
- The vulnerability is present (Laravel and Ignition versions are correct).
- The exploit script runs without errors but does not execute commands (likely due to gadget chain incompatibility with PHP 8.1). Further debugging may be needed.

## What was NOT tested (due to lack of working shell)
- Privilege escalation via SUID bash (not verified).
- Coronation and no-cheat checks.

## Recommendation
The maintainer should investigate a compatible gadget chain (e.g., `Monolog/RCE2`, `Symfony/RCE1`) or adjust PHP configuration to fully enable RCE. Once a shell is obtained, SUID bash should provide root.